### PR TITLE
Enforce use for component interactivity

### DIFF
--- a/packages/components/src/global/Buttons/Button.tsx
+++ b/packages/components/src/global/Buttons/Button.tsx
@@ -1,7 +1,7 @@
 import { JSX } from '@hd-web/jsx'
 import { ButtonType } from './types.js'
 import { interact } from '@hd-web/build'
-import { buttonInteract } from './buttonInteract.js'
+import { useButton } from './useButton.js'
 import { attachIdToElement } from '../../shared/getContainerElement.js'
 
 export type ButtonProps = {
@@ -15,7 +15,7 @@ export const Button: JSX.FuncComponent<ButtonProps> = ({
   disabled = false,
   title
 }) => {
-  const id = interact(buttonInteract)
+  const id = interact(useButton)
 
   return (
     <button

--- a/packages/components/src/global/Buttons/index.ts
+++ b/packages/components/src/global/Buttons/index.ts
@@ -1,4 +1,3 @@
-import { stopLoading, startLoading, isLoading } from './buttonInteract.js'
-export const ButtonUtils = { stopLoading, startLoading, isLoading }
+export * as ButtonUtils from './utils.js'
 export { type ButtonProps, Button } from './Button.js'
 export { LinkButton, type LinkButtonProps } from './LinkButton.js'

--- a/packages/components/src/global/Buttons/useButton.ts
+++ b/packages/components/src/global/Buttons/useButton.ts
@@ -1,19 +1,8 @@
 import { InteractCallback } from '@hd-web/build'
 import { getContainerElement } from '../../shared/getContainerElement.js'
+import { isLoading } from './utils.js'
 
-export const startLoading = (button: Element) => {
-  button.classList.add('Button--loading')
-}
-
-export const stopLoading = (button: Element) => {
-  button.classList.remove('Button--loading')
-}
-
-export const isLoading = (button: Element) => {
-  return button.classList.contains('Button--loading')
-}
-
-export const buttonInteract: InteractCallback = (id) => {
+export const useButton: InteractCallback = (id) => {
   const button = getContainerElement(id, 'button')
 
   button.addEventListener('click', (e) => {

--- a/packages/components/src/global/Buttons/utils.ts
+++ b/packages/components/src/global/Buttons/utils.ts
@@ -1,0 +1,11 @@
+export const startLoading = (button: Element) => {
+  button.classList.add('Button--loading')
+}
+
+export const stopLoading = (button: Element) => {
+  button.classList.remove('Button--loading')
+}
+
+export const isLoading = (button: Element) => {
+  return button.classList.contains('Button--loading')
+}

--- a/packages/components/src/local/Carousel/Carousel.tsx
+++ b/packages/components/src/local/Carousel/Carousel.tsx
@@ -4,6 +4,7 @@ import { type JSX } from '@hd-web/jsx'
 import { useCarousel } from './useCarousel.js'
 import { interact } from '@hd-web/build'
 import { attachIdToElement } from '@hd-web/components'
+import { appendUniqueId } from '../../shared/appendUniqueId.js'
 
 export type CarouselProps = {
   items: JSX.Element[]
@@ -34,6 +35,8 @@ export const Carousel: JSX.FuncComponent<CarouselProps> = ({
     gap
   })
 
+  const itemsId = appendUniqueId('hd-carousel-items', id)
+
   return (
     <div
       class="hd-carousel"
@@ -45,7 +48,7 @@ export const Carousel: JSX.FuncComponent<CarouselProps> = ({
       <button
         class="hd-carousel__prev"
         aria-label="Previous"
-        aria-controls="hd-carousel-items"
+        aria-controls={itemsId}
       >
         {prevIcon}
       </button>
@@ -54,7 +57,7 @@ export const Carousel: JSX.FuncComponent<CarouselProps> = ({
           class="hd-carousel__items"
           style={{ gap }}
           aria-live="polite"
-          id="hd-carousel-items"
+          id={itemsId}
         >
           {items.map((item, index) => {
             return (
@@ -73,7 +76,7 @@ export const Carousel: JSX.FuncComponent<CarouselProps> = ({
       <button
         class="hd-carousel__next"
         aria-label="Next"
-        aria-controls="hd-carousel-items"
+        aria-controls={itemsId}
       >
         {nextIcon}
       </button>

--- a/packages/components/src/local/Carousel/Carousel.tsx
+++ b/packages/components/src/local/Carousel/Carousel.tsx
@@ -1,7 +1,7 @@
 import './Carousel.css'
 
 import { type JSX } from '@hd-web/jsx'
-import { carousel } from './carouselInteract.js'
+import { useCarousel } from './useCarousel.js'
 import { interact } from '@hd-web/build'
 import { attachIdToElement } from '@hd-web/components'
 
@@ -27,7 +27,7 @@ export const Carousel: JSX.FuncComponent<CarouselProps> = ({
   maxItemsPerSlide = Infinity,
   gap = 'var(--sp-400)'
 }) => {
-  const id = interact(carousel, {
+  const id = interact(useCarousel, {
     minWidth,
     maxItemsPerSlide,
     itemCount: items.length,

--- a/packages/components/src/local/Carousel/useCarousel.ts
+++ b/packages/components/src/local/Carousel/useCarousel.ts
@@ -1,19 +1,19 @@
 import { InteractCallback } from '@hd-web/build'
 import { getContainerElement } from '../../shared/getContainerElement.js'
 
-type HdCarouselProps = {
+type UseCarouselProps = {
   minWidth: number
   maxItemsPerSlide: number
   itemCount: number
   gap: string
 }
 
-export const carousel: InteractCallback<HdCarouselProps> = (
+export const useCarousel: InteractCallback<UseCarouselProps> = (
   id,
   { minWidth, maxItemsPerSlide, itemCount, gap }
 ) => {
-  const container = getContainerElement(id, 'carousel')
-  const itemsDiv = container.querySelector(
+  const carousel = getContainerElement(id, 'carousel')
+  const itemsDiv = carousel.querySelector(
     '.hd-carousel__items'
   ) as HTMLDivElement
 
@@ -60,8 +60,8 @@ export const carousel: InteractCallback<HdCarouselProps> = (
     )
   }
 
-  container.querySelector('.hd-carousel__prev')?.addEventListener('click', prev)
-  container.querySelector('.hd-carousel__next')?.addEventListener('click', next)
+  carousel.querySelector('.hd-carousel__prev')?.addEventListener('click', prev)
+  carousel.querySelector('.hd-carousel__next')?.addEventListener('click', next)
 
   // Each time the itemsDiv is resized, we make sure each item is wider
   // than the minimum width

--- a/packages/components/src/local/Form/index.ts
+++ b/packages/components/src/local/Form/index.ts
@@ -1,1 +1,1 @@
-export { formInteract as form } from './form.js'
+export { useForm, type UseFormProps } from './useForm.js'

--- a/packages/components/src/local/Form/useForm.ts
+++ b/packages/components/src/local/Form/useForm.ts
@@ -4,14 +4,14 @@ import { InteractCallback } from '@hd-web/build'
 import { ButtonUtils } from '../../global/index.js'
 import { getContainerElement } from '../../shared/getContainerElement.js'
 
-export type FormProps = {
+export type UseFormProps = {
   action: string
 }
 
 const successMessage =
   "Thanks, we've received your message and will be in touch"
 
-export const formInteract: InteractCallback<FormProps> = (id, { action }) => {
+export const useForm: InteractCallback<UseFormProps> = (id, { action }) => {
   const form = getContainerElement(id, 'form') as HTMLFormElement
 
   let startedTyping: number | null = null

--- a/packages/components/src/local/Header/Header.tsx
+++ b/packages/components/src/local/Header/Header.tsx
@@ -1,7 +1,7 @@
 import './Header.css'
 import { JSX } from '@hd-web/jsx'
 import type { HeaderProps } from './types.js'
-import { header } from './headerInteract.js'
+import { useHeader } from './useHeader.js'
 import { MenuButton } from './MenuButton.js'
 import { interact } from '@hd-web/build'
 import { attachIdToElement } from '../../shared/getContainerElement.js'
@@ -14,7 +14,7 @@ export const Header: JSX.FuncComponent<HeaderProps> = ({
   bgColour,
   fontColour
 }) => {
-  const id = interact(header)
+  const id = interact(useHeader)
 
   return (
     <nav

--- a/packages/components/src/local/Header/MenuButton.tsx
+++ b/packages/components/src/local/Header/MenuButton.tsx
@@ -15,6 +15,7 @@ export const MenuButton: JSX.FuncComponent<MenuButtonProps> = ({
       class={`MenuButton ${className}`}
       aria-haspopup="menu"
       aria-label="Open Navigation Menu"
+      aria-expanded="false"
     >
       <svg
         viewBox="0 0 100 100"

--- a/packages/components/src/local/Header/MenuButton.tsx
+++ b/packages/components/src/local/Header/MenuButton.tsx
@@ -11,7 +11,11 @@ export const MenuButton: JSX.FuncComponent<MenuButtonProps> = ({
   className
 }) => {
   return (
-    <button class={`MenuButton ${className}`}>
+    <button
+      class={`MenuButton ${className}`}
+      aria-haspopup="menu"
+      aria-label="Open Navigation Menu"
+    >
       <svg
         viewBox="0 0 100 100"
         height={height}

--- a/packages/components/src/local/Header/useHeader.ts
+++ b/packages/components/src/local/Header/useHeader.ts
@@ -9,7 +9,9 @@ export const useHeader: InteractCallback = (id) => {
     el.querySelector('.hd-header_links')!.classList[type](
       'hd-header_links--show'
     )
-    el.querySelector('.MenuButton')!.classList[type]('MenuButton--open')
+    const button = el.querySelector('.MenuButton')!
+    button.classList[type]('MenuButton--open')
+    button.ariaExpanded = show ? 'true' : 'false'
   }
 
   const handleClick = (e: MouseEvent) => {

--- a/packages/components/src/local/Header/useHeader.ts
+++ b/packages/components/src/local/Header/useHeader.ts
@@ -1,8 +1,8 @@
 import { InteractCallback } from '@hd-web/build'
 import { getContainerElement } from '../../shared/getContainerElement.js'
 
-export const header: InteractCallback = (id) => {
-  const container = getContainerElement(id, 'header') as HTMLElement
+export const useHeader: InteractCallback = (id) => {
+  const header = getContainerElement(id, 'header') as HTMLElement
 
   const showHideMenu = (el: Element, show: boolean) => {
     const type = show ? 'add' : 'remove'
@@ -40,5 +40,5 @@ export const header: InteractCallback = (id) => {
     }
   }
 
-  container.addEventListener('click', handleClick)
+  header.addEventListener('click', handleClick)
 }

--- a/packages/components/src/shared/appendUniqueId.ts
+++ b/packages/components/src/shared/appendUniqueId.ts
@@ -1,0 +1,5 @@
+/**
+ * Given an id for a specific part of a component, generate a new,
+ * unique id using the unique id number for the whole component.
+ */
+export const appendUniqueId = (id: string, uid: number) => `${id}-${uid}`

--- a/packages/components/src/shared/index.ts
+++ b/packages/components/src/shared/index.ts
@@ -1,1 +1,2 @@
 export * from './getContainerElement.js'
+export * from './appendUniqueId.js'


### PR DESCRIPTION
Each function which provides interactivity via the interact function should start with use, similar to a React hook

Also fix some a11y issues with the header