### PR TITLE
Hook to replace form on success and support multiple hooks

### DIFF
--- a/packages/.changeset/nervous-rivers-mate.md
+++ b/packages/.changeset/nervous-rivers-mate.md
@@ -1,0 +1,15 @@
+---
+'@hd-web/components': patch
+'@hd-web/create': patch
+'@hd-web/build': patch
+---
+
+Support multiple interactivity hooks by passing in the id
+
+Rename InteractCallback to InteractHook
+
+Add new hook to replace form with success message
+
+Add status component to use in this hook
+
+Add css variables for status colours to the create template

--- a/packages/build/src/index.ts
+++ b/packages/build/src/index.ts
@@ -1,8 +1,4 @@
 export { buildSite } from './site/buildSite.js'
 export { startDev } from './dev/startDev.js'
 export type { Page } from './shared/types.js'
-export {
-  interact,
-  interactMultiple,
-  type InteractHook
-} from './shared/interactivity.js'
+export { interact, type InteractHook } from './shared/interactivity.js'

--- a/packages/build/src/index.ts
+++ b/packages/build/src/index.ts
@@ -1,4 +1,8 @@
 export { buildSite } from './site/buildSite.js'
 export { startDev } from './dev/startDev.js'
 export type { Page } from './shared/types.js'
-export { interact, type InteractCallback } from './shared/interactivity.js'
+export {
+  interact,
+  interactMultiple,
+  type InteractHook
+} from './shared/interactivity.js'

--- a/packages/build/src/shared/interactivity.ts
+++ b/packages/build/src/shared/interactivity.ts
@@ -40,41 +40,31 @@ const getNewId = () => globalThis._hdInteractions.length
  * Also provides you with a unique id to use for selecting instances
  * of components.
  *
+ * Or you can pass in `idOverride` to pass that id into the hook instead
+ * of this uniquely created one. This can be useful if using more than
+ * one hook within a component.
+ *
  * NB the hook must be defined outside the scope of the component.
  */
 export function interact(
   hook: InteractHook<undefined>,
-  args?: undefined
+  args?: undefined,
+  idOverride?: number
 ): number
 
-export function interact<T>(hook: InteractHook<T>, args: T): number
-
-export function interact<T>(hook: InteractHook<T>, args: T) {
-  const id = getNewId()
-  addInteraction(getCallbackName(hook), args, id)
-
-  return id
-}
-
-/**
- * Register all the hooks and their associated args with the same id
- * passed to each.
- *
- * @see `interact`
- */
-export function interactMultiple(...hooks: Array<[hook: InteractHook]>): number
-
-export function interactMultiple<T>(
-  ...hooks: Array<[hook: InteractHook<T>, args: T]>
+export function interact<T>(
+  hook: InteractHook<T>,
+  args: T,
+  idOverride?: number
 ): number
 
-export function interactMultiple<T>(
-  ...hooks: Array<[hook: InteractHook<T>, args?: T]>
+export function interact<T>(
+  hook: InteractHook<T>,
+  args: T,
+  idOverride?: number
 ) {
-  const id = getNewId()
-  hooks.forEach(([hook, args]) =>
-    addInteraction(getCallbackName(hook), args, id)
-  )
+  const id = idOverride ?? getNewId()
+  addInteraction(getCallbackName(hook), args, id)
 
   return id
 }

--- a/packages/components/src/global/Buttons/useButton.ts
+++ b/packages/components/src/global/Buttons/useButton.ts
@@ -1,8 +1,8 @@
-import { InteractCallback } from '@hd-web/build'
+import { InteractHook } from '@hd-web/build'
 import { getContainerElement } from '../../shared/getContainerElement.js'
 import { isLoading } from './utils.js'
 
-export const useButton: InteractCallback = (id) => {
+export const useButton: InteractHook = (id) => {
   const button = getContainerElement(id, 'button')
 
   button.addEventListener('click', (e) => {

--- a/packages/components/src/global/Status/Status.css
+++ b/packages/components/src/global/Status/Status.css
@@ -1,0 +1,18 @@
+.hd-status {
+  border-radius: 4px;
+  border-width: 2px;
+  border-style: solid;
+  padding: var(--sp-500) var(--sp-400);
+}
+
+.hd-status--success {
+  border-color: var(--success-dark);
+  color: var(--success-dark);
+  background-color: var(--success-light);
+}
+
+.hd-status--error {
+  border-color: var(--error-dark);
+  color: var(--error-dark);
+  background-color: var(--error-light);
+}

--- a/packages/components/src/global/Status/Status.tsx
+++ b/packages/components/src/global/Status/Status.tsx
@@ -1,0 +1,12 @@
+import './Status.css'
+
+import { type JSX } from '@hd-web/jsx'
+
+export type StatusProps = {
+  type: 'success' | 'error'
+  message: string
+}
+
+export const Status: JSX.FuncComponent<StatusProps> = ({ type, message }) => {
+  return <div class={`hd-status hd-status--${type}`}>{message}</div>
+}

--- a/packages/components/src/global/Status/Status.tsx
+++ b/packages/components/src/global/Status/Status.tsx
@@ -8,5 +8,9 @@ export type StatusProps = {
 }
 
 export const Status: JSX.FuncComponent<StatusProps> = ({ type, message }) => {
-  return <div class={`hd-status hd-status--${type}`}>{message}</div>
+  return (
+    <div class={`hd-status hd-status--${type}`}>
+      <p>{message}</p>
+    </div>
+  )
 }

--- a/packages/components/src/global/Status/index.ts
+++ b/packages/components/src/global/Status/index.ts
@@ -1,0 +1,1 @@
+export { type StatusProps, Status } from './Status.js'

--- a/packages/components/src/global/index.ts
+++ b/packages/components/src/global/index.ts
@@ -1,1 +1,2 @@
 export * from './Buttons/index.js'
+export * from './Status/index.js'

--- a/packages/components/src/local/Carousel/useCarousel.ts
+++ b/packages/components/src/local/Carousel/useCarousel.ts
@@ -1,4 +1,4 @@
-import { InteractCallback } from '@hd-web/build'
+import { InteractHook } from '@hd-web/build'
 import { getContainerElement } from '../../shared/getContainerElement.js'
 
 type UseCarouselProps = {
@@ -8,7 +8,7 @@ type UseCarouselProps = {
   gap: string
 }
 
-export const useCarousel: InteractCallback<UseCarouselProps> = (
+export const useCarousel: InteractHook<UseCarouselProps> = (
   id,
   { minWidth, maxItemsPerSlide, itemCount, gap }
 ) => {

--- a/packages/components/src/local/Form/addTermsField.ts
+++ b/packages/components/src/local/Form/addTermsField.ts
@@ -1,33 +1,26 @@
+import { appendUniqueId } from '../../shared/appendUniqueId.js'
+
 const formError = () => new Error('Form not provided')
 
-const termsId = 'terms'
-const termsLabelId = 'termsLabel'
+const termsId = '_terms'
+const termsLabelId = '_termsLabel'
 
-export const removeTermsField = (form: HTMLFormElement | null) => {
-  if (!form) {
-    throw formError()
-  }
-
-  form.querySelector(`#${termsId}`)?.remove()
-  form.querySelector(`#${termsLabelId}`)?.remove()
-}
-
-export const addTermsField = (form: HTMLFormElement | null) => {
+export const addTermsField = (id: number, form: HTMLFormElement | null) => {
   if (!form) {
     throw formError()
   }
 
   const terms = document.createElement('input')
   terms.name = 'terms'
-  terms.id = termsId
+  terms.id = appendUniqueId(termsId, id)
   terms.type = 'checkbox'
   terms.tabIndex = -1
   terms.autocomplete = 'off'
   terms.style.display = 'none'
 
   const label = document.createElement('label')
-  label.htmlFor = termsId
-  label.id = termsLabelId
+  label.htmlFor = appendUniqueId(termsId, id)
+  label.id = appendUniqueId(termsLabelId, id)
   label.textContent = 'Do you accept the T&Cs?'
   label.style.display = 'none'
 

--- a/packages/components/src/local/Form/events.ts
+++ b/packages/components/src/local/Form/events.ts
@@ -1,0 +1,24 @@
+export type HdFormSuccessDetail = {
+  type: 'success'
+}
+
+export type HdFormFailureDetail = {
+  type: 'failure'
+  message: string
+}
+
+export type HdFormDetail = HdFormFailureDetail | HdFormSuccessDetail
+
+export const hdFormEventKey = 'hd-form-event' as const
+
+export class HdFormEvent extends CustomEvent<HdFormDetail> {
+  constructor(detail: HdFormDetail) {
+    super(hdFormEventKey, { detail })
+  }
+}
+
+declare global {
+  interface GlobalEventHandlersEventMap {
+    [hdFormEventKey]: HdFormEvent
+  }
+}

--- a/packages/components/src/local/Form/index.ts
+++ b/packages/components/src/local/Form/index.ts
@@ -1,2 +1,2 @@
-export { useForm, type UseFormProps } from './useForm.js'
+export { usePostForm, type UsePostFormProps } from './usePostForm.js'
 export { HdFormEvent, hdFormEventKey } from './events.js'

--- a/packages/components/src/local/Form/index.ts
+++ b/packages/components/src/local/Form/index.ts
@@ -1,1 +1,2 @@
 export { useForm, type UseFormProps } from './useForm.js'
+export { HdFormEvent, hdFormEventKey } from './events.js'

--- a/packages/components/src/local/Form/index.ts
+++ b/packages/components/src/local/Form/index.ts
@@ -1,2 +1,3 @@
 export { usePostForm, type UsePostFormProps } from './usePostForm.js'
+export { useClearFormOnSuccess } from './useClearFormOnSuccess.js'
 export { HdFormEvent, hdFormEventKey } from './events.js'

--- a/packages/components/src/local/Form/useClearFormOnSuccess.ts
+++ b/packages/components/src/local/Form/useClearFormOnSuccess.ts
@@ -1,0 +1,30 @@
+import { InteractHook } from '@hd-web/build'
+import { type JSX } from '@hd-web/jsx'
+
+import { getContainerElement } from '../../shared/index.js'
+import { hdFormEventKey } from './events.js'
+
+export type UseClearFormOnSuccess = {
+  element: JSX.Element
+}
+
+/**
+ * Listen for an `HdFormEvent` representing a successful form submission
+ * and replace the form element with `element`
+ */
+export const useClearFormOnSuccess: InteractHook<UseClearFormOnSuccess> = (
+  id,
+  { element }
+) => {
+  const container = getContainerElement(id, 'form') as HTMLElement
+  const form = container.querySelector('form')!
+  const template = document.createElement('template')
+  template.innerHTML = element ?? ''
+  const successElement = template.content
+
+  form.addEventListener(hdFormEventKey, (event) => {
+    if (event.detail.type === 'success') {
+      form.replaceWith(successElement)
+    }
+  })
+}

--- a/packages/components/src/local/Form/useForm.ts
+++ b/packages/components/src/local/Form/useForm.ts
@@ -1,4 +1,4 @@
-import { InteractCallback } from '@hd-web/build'
+import { InteractHook } from '@hd-web/build'
 
 import { addTermsField } from './addTermsField.js'
 import { ButtonUtils } from '../../global/index.js'
@@ -21,7 +21,7 @@ export type UseFormProps = {
  * A hidden terms field with the name `"terms"` will be added in order to
  * check for bots.
  */
-export const useForm: InteractCallback<UseFormProps> = (id, { action }) => {
+export const useForm: InteractHook<UseFormProps> = (id, { action }) => {
   const container = getContainerElement(id, 'form') as HTMLElement
 
   let pageLoaded = Date.now()

--- a/packages/components/src/local/Form/usePostForm.ts
+++ b/packages/components/src/local/Form/usePostForm.ts
@@ -5,7 +5,7 @@ import { ButtonUtils } from '../../global/index.js'
 import { getContainerElement } from '../../shared/getContainerElement.js'
 import { HdFormDetail, HdFormEvent } from './events.js'
 
-export type UseFormProps = {
+export type UsePostFormProps = {
   action: string
 }
 
@@ -21,7 +21,7 @@ export type UseFormProps = {
  * A hidden terms field with the name `"terms"` will be added in order to
  * check for bots.
  */
-export const useForm: InteractHook<UseFormProps> = (id, { action }) => {
+export const usePostForm: InteractHook<UsePostFormProps> = (id, { action }) => {
   const container = getContainerElement(id, 'form') as HTMLElement
 
   let pageLoaded = Date.now()

--- a/packages/components/src/local/Form/usePostForm.ts
+++ b/packages/components/src/local/Form/usePostForm.ts
@@ -2,7 +2,7 @@ import { InteractHook } from '@hd-web/build'
 
 import { addTermsField } from './addTermsField.js'
 import { ButtonUtils } from '../../global/index.js'
-import { getContainerElement } from '../../shared/getContainerElement.js'
+import { getContainerElement } from '../../shared/index.js'
 import { HdFormDetail, HdFormEvent } from './events.js'
 
 export type UsePostFormProps = {

--- a/packages/components/src/local/Header/useHeader.ts
+++ b/packages/components/src/local/Header/useHeader.ts
@@ -1,7 +1,7 @@
-import { InteractCallback } from '@hd-web/build'
+import { InteractHook } from '@hd-web/build'
 import { getContainerElement } from '../../shared/getContainerElement.js'
 
-export const useHeader: InteractCallback = (id) => {
+export const useHeader: InteractHook = (id) => {
   const header = getContainerElement(id, 'header') as HTMLElement
 
   const showHideMenu = (el: Element, show: boolean) => {

--- a/packages/create/template/src/variables.css
+++ b/packages/create/template/src/variables.css
@@ -67,6 +67,12 @@
   --grey-700: #7c8a9c;
   --grey-800: #9fb3cc;
   --grey-900: #dce6f4;
+
+  --success-light: #b9e9c4;
+  --success-dark: #10421c;
+
+  --error-light: #edc9ce;
+  --error-dark: #620e16;
 }
 
 @media (max-width: 500px) {


### PR DESCRIPTION
Support multiple interactivity hooks by passing in the id

Rename `InteractCallback` to `InteractHook`

Add new hook to replace form with success message

Add status component to use in this hook